### PR TITLE
Remove old socket listeners before adding new ones

### DIFF
--- a/lib/json-rpc-interface.js
+++ b/lib/json-rpc-interface.js
@@ -107,18 +107,29 @@ class JSONRPCInterface extends APIInterface {
 				routeOptions: options
 			};
 
+			// Because multiple API calls can use the same socket (HTTP keepalive), we need
+			// to remove any previous socket handlers added by yaar before adding new ones.
+			for (let eventName of res.socket.eventNames()) {
+				for (let listener of res.socket.listeners(eventName)) {
+					if (listener._isYaarHandler) {
+						res.socket.removeListener(eventName, listener);
+					}
+				}
+			}
+
 			// Add 'connection-closed' hook to ctx.
 			CrispHooks.addHooks(ctx);
 			let connectionClosedTriggered = false;
-			const triggerConnnectionClosed = () => {
+			const triggerConnectionClosed = () => {
 				if (!connectionClosedTriggered) {
 					connectionClosedTriggered = true;
 					ctx.trigger('connection-closed').catch(pasync.abort);
 				}
 			};
-			res.on('close', triggerConnnectionClosed);
-			res.socket.on('error', triggerConnnectionClosed);
-			res.socket.on('timeout', triggerConnnectionClosed);
+			triggerConnectionClosed._isYaarHandler = true;
+			res.on('close', triggerConnectionClosed);
+			res.socket.on('error', triggerConnectionClosed);
+			res.socket.on('timeout', triggerConnectionClosed);
 
 			// Set up keep-alive
 			let keepAlive = null;
@@ -146,13 +157,17 @@ class JSONRPCInterface extends APIInterface {
 				// Register event handlers in case of manualResponse
 				.then((ctx) => {
 					if (options.manualResponse) {
-						res.socket.on('end', () => {
+						const socketEndHandler = () => {
 							this.apiRouter._triggerRequestEnd(ctx, true).catch(pasync.abort);
-						});
-						res.socket.on('error', (error) => {
-							error = new XError(XError.REQUEST_ERROR, error);
-							this.apiRouter._triggerRequestError(ctx, error, true).catch(pasync.abort);
-						});
+						};
+						socketEndHandler._isYaarHandler = true;
+						const socketErrorHandler = (err) => {
+							err = new XError(XError.REQUEST_ERROR, err);
+							this.apiRouter._triggerRequestError(ctx, err, true).catch(pasync.abort);
+						};
+						socketErrorHandler._isYaarHandler = true;
+						res.socket.on('end', socketEndHandler);
+						res.socket.on('error', socketErrorHandler);
 					}
 					return ctx;
 				})
@@ -272,7 +287,8 @@ class JSONRPCInterface extends APIInterface {
 						this.apiRouter._triggerRequestEnd(ctx, true).catch(pasync.abort);
 						res.end(JSON.stringify(response));
 					}
-				});
+				})
+				.catch(pasync.abort);
 		};
 	}
 


### PR DESCRIPTION
Because HTTP keepalive can result in the same socket being used for multiple requests, some of these socket event listeners being added are being added more than once, or incorrectly.  This marks all socket yaar listeners with a flag and removes them before re-registering.